### PR TITLE
Fix datetime conversion failures observed with NumPy 2.5

### DIFF
--- a/cdflib/epochs.py
+++ b/cdflib/epochs.py
@@ -170,7 +170,9 @@ class CDFepoch:
         """
         Take date components and return a numpy datetime array.
         """
-        years = np.asarray(years) - 1970
+        # Keep fill and pad dates within the datetime64[ns] range while the
+        # components are composed. These positions are replaced with NaT below.
+        years = np.where(nat_positions, 0, np.asarray(years) - 1970)
         months = np.asarray(months) - 1
         days = np.asarray(days) - 1
         types = ("<M8[Y]", "<m8[M]", "<m8[D]", "<m8[h]", "<m8[m]", "<m8[s]", "<m8[ms]", "<m8[us]", "<m8[ns]")

--- a/cdflib/xarray/xarray_to_cdf.py
+++ b/cdflib/xarray/xarray_to_cdf.py
@@ -1230,7 +1230,11 @@ def xarray_to_cdf(
                     # ISTP defines BIN_LOCATION as a REAL*4 variable attribute.
                     # See https://spdf.gsfc.nasa.gov/istp_guide/vattributes.html#BIN_LOCATION
                     var_att_dict[att] = [np.float32(att_value), "CDF_REAL4"]
-                elif (att == "VALIDMIN" or att == "VALIDMAX" or att == "FILLVAL") and istp:
+                elif (
+                    att in ("VALIDMIN", "VALIDMAX", "FILLVAL")
+                    and istp
+                    and DATATYPES_TO_STRINGS[cdf_data_type] not in ("CDF_EPOCH", "CDF_EPOCH16", "CDF_TIME_TT2000")
+                ):
                     var_att_dict[att] = [att_value, DATATYPES_TO_STRINGS[cdf_data_type]]
 
             var_spec = {


### PR DESCRIPTION
# Overview

Closes #343 

## Description

This PR fixes datetime conversion failures observed with NumPy 2.5 by:
- Adopting a representable placeholder year while composing fill/pad timestamps before converting them to NaT, preventing a segmentation fault.
- Preserving numeric `FILLVAL`, `VALIDMIN`, and `VALIDMAX` metadata on CDF time variables, preventing TT2000 overflow during xarray round trips.

## Testing
Running:
```shell
uv sync --extra tests
uv run pytest
```
results in 82 passed, 25 skipped, 46 warnings. Running:
```shell
uv run pytest --remote-data
```
results in previously failing tests passing (though, admittedly, I am getting a couple of persistent `urllib.error.HTTPError: HTTP Error 429: Too Many Requests` errors locally).